### PR TITLE
Add default column to model

### DIFF
--- a/src/qmonus_plugin_builder/templates/__init__.py
+++ b/src/qmonus_plugin_builder/templates/__init__.py
@@ -128,6 +128,9 @@ metadata = sqlalchemy.MetaData()
     sqlalchemy.Column("{{ variable.name }}"),
     {% endfor %}
     {% endfor %}
+    sqlalchemy.Column("instance"),
+    sqlalchemy.Column("xid"),
+    sqlalchemy.Column("xname"),
 )
 
 {% endfor %}


### PR DESCRIPTION
- 自動生成されるmodel.pyにデフォルトで必ず付加されるカラム(instance, xid, xname)を追加。
  - instanceなどでクエリの比較を行うことがあるため、このカラムも追加したいです。